### PR TITLE
fix(ci): use RELEASE_TOKEN to bypass protected branch in semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
-          persist-credentials: false
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Setup Java
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
@@ -44,7 +44,7 @@ jobs:
       - name: Run semantic-release
         run: npx --no-install semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           ONELITEFEATHER_MAVEN_USERNAME: ${{ secrets.ONELITEFEATHER_MAVEN_USERNAME }}
           ONELITEFEATHER_MAVEN_PASSWORD: ${{ secrets.ONELITEFEATHER_MAVEN_PASSWORD }}
           GIT_AUTHOR_NAME: "github-actions[bot]"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,11 +16,18 @@ jobs:
     if: github.repository_owner == 'OneLiteFeatherNET'
     runs-on: ubuntu-latest
     steps:
+      - name: Generate bot token
+        id: app-token
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713a63b1132f8e3a # v2
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Java
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
@@ -44,7 +51,7 @@ jobs:
       - name: Run semantic-release
         run: npx --no-install semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           ONELITEFEATHER_MAVEN_USERNAME: ${{ secrets.ONELITEFEATHER_MAVEN_USERNAME }}
           ONELITEFEATHER_MAVEN_PASSWORD: ${{ secrets.ONELITEFEATHER_MAVEN_PASSWORD }}
           GIT_AUTHOR_NAME: "github-actions[bot]"


### PR DESCRIPTION
## Summary

- Replaces `persist-credentials: false` + `GITHUB_TOKEN` with `RELEASE_TOKEN` (PAT) in the release workflow
- `GITHUB_TOKEN` cannot push to `main` because branch protection requires PRs and 3 status checks
- A PAT with `repo` scope and branch-bypass permission is the standard fix for this semantic-release pattern

## Required Action Before Merging

1. Create a **Personal Access Token** (classic, `repo` scope) for the release bot account (or `github-actions[bot]` equivalent)
2. Add it as a repository secret named **`RELEASE_TOKEN`**
3. In **Settings → Branches → main protection rule**, add the token owner (or the GitHub App) to the bypass list

## Test plan

- [ ] `RELEASE_TOKEN` secret is created and added to the repo
- [ ] Branch protection bypass is configured for the token owner
- [ ] Next release run completes without `GH006` error

Closes #151