### PR TITLE
fix(build): update foojay to 1.0.0, fix hotswap GC and agent resolution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
-          persist-credentials: false
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Setup Java
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
@@ -44,7 +44,7 @@ jobs:
       - name: Run semantic-release
         run: npx --no-install semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           ONELITEFEATHER_MAVEN_USERNAME: ${{ secrets.ONELITEFEATHER_MAVEN_USERNAME }}
           ONELITEFEATHER_MAVEN_PASSWORD: ${{ secrets.ONELITEFEATHER_MAVEN_PASSWORD }}
           GIT_AUTHOR_NAME: "github-actions[bot]"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,11 +16,18 @@ jobs:
     if: github.repository_owner == 'OneLiteFeatherNET'
     runs-on: ubuntu-latest
     steps:
+      - name: Generate bot token
+        id: app-token
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713a63b1132f8e3a # v2
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Java
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
@@ -44,7 +51,7 @@ jobs:
       - name: Run semantic-release
         run: npx --no-install semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           ONELITEFEATHER_MAVEN_USERNAME: ${{ secrets.ONELITEFEATHER_MAVEN_USERNAME }}
           ONELITEFEATHER_MAVEN_PASSWORD: ${{ secrets.ONELITEFEATHER_MAVEN_PASSWORD }}
           GIT_AUTHOR_NAME: "github-actions[bot]"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Generate bot token
         id: app-token
-        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713a63b1132f8e3a # v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -33,7 +33,7 @@ dependencies {
     testImplementation("org.mockito:mockito-core")
     testImplementation("org.mockito:mockito-junit-jupiter")
 
-    hotswapAgent("org.hotswapagent:hotswap-agent:2.0.3")
+    hotswapAgent("org.hotswapagent:hotswap-agent:2.0.3") { isTransitive = false }
 }
 
 java {
@@ -81,7 +81,7 @@ tasks {
         jvmArgs(
             "-XX:+AllowEnhancedClassRedefinition",
             "-XX:HotswapAgent=external",
-            "-XX:+UseZGC",
+            "-XX:+UseG1GC",
             "-XX:+UseCompactObjectHeaders",
             "-Xms256M",
             "-Xmx512M",

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,7 +1,7 @@
 rootProject.name = "Voyager"
 
 plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.10.0"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 
 dependencyResolutionManagement {


### PR DESCRIPTION
## Summary

- Bump `foojay-resolver-convention` 0.10.0 → 1.0.0 to fix `IBM_SEMERU` field removal in Gradle 9.x `JvmVendorSpec`
- Switch `runServerHotswap` from ZGC to G1GC — JBR enhanced class redefinition requires Serial or G1 GC
- Mark `hotswapAgent` dependency non-transitive so `singleFile` resolves exactly one JAR
- Fix pinned SHA for `actions/create-github-app-token@v2` in release workflow (SHA was invalid)

## Test plan

- [ ] `./gradlew :server:runServerHotswap` starts without errors
- [ ] `./gradlew build` completes successfully
- [ ] Release workflow resolves `create-github-app-token` action without error