### PR TITLE
fix(build): update foojay to 1.0.0, fix hotswap GC and agent resolution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Generate bot token
         id: app-token
-        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713a63b1132f8e3a # v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -33,7 +33,7 @@ dependencies {
     testImplementation("org.mockito:mockito-core")
     testImplementation("org.mockito:mockito-junit-jupiter")
 
-    hotswapAgent("org.hotswapagent:hotswap-agent:2.0.3")
+    hotswapAgent("org.hotswapagent:hotswap-agent:2.0.3") { isTransitive = false }
 }
 
 java {
@@ -81,7 +81,7 @@ tasks {
         jvmArgs(
             "-XX:+AllowEnhancedClassRedefinition",
             "-XX:HotswapAgent=external",
-            "-XX:+UseZGC",
+            "-XX:+UseG1GC",
             "-XX:+UseCompactObjectHeaders",
             "-Xms256M",
             "-Xmx512M",

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,7 +1,7 @@
 rootProject.name = "Voyager"
 
 plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.10.0"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 
 dependencyResolutionManagement {


### PR DESCRIPTION
## Summary

- Bump `foojay-resolver-convention` 0.10.0 → 1.0.0 — fixes `IBM_SEMERU` field removed in Gradle 9.x `JvmVendorSpec`
- Switch `runServerHotswap` from ZGC → G1GC — JBR enhanced class redefinition requires Serial or G1 GC
- Mark `hotswapAgent` dependency non-transitive so `singleFile` resolves exactly one JAR
- Fix pinned SHA for `actions/create-github-app-token@v2` (old SHA was invalid)

## Test plan

- [ ] `./gradlew :server:runServerHotswap` starts without errors
- [ ] `./gradlew build` completes successfully
- [ ] Release workflow resolves `create-github-app-token` action without error