### PR TITLE
chore(renovate): migrate to OneLiteFeatherNET org presets

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,20 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended",
-    ":semanticCommitsDisabled"
-  ],
-  "ignoreDeps": [],
-  "labels": [
-    "Renovate"
-  ],
-  "rebaseWhen": "conflicted",
-  "packageRules": [
-    {
-      "matchUpdateTypes": [
-        "patch"
-      ],
-      "automerge": true
-    }
+    "github>OneLiteFeatherNET/renovate:default(OneLiteFeatherNET/voyager-maintainers)",
+    "github>OneLiteFeatherNET/renovate:minestom",
+    "github>OneLiteFeatherNET/renovate:paper"
   ]
 }


### PR DESCRIPTION
## Summary

- Replace manual Renovate config with shared org presets from `OneLiteFeatherNET/renovate`
- Use `default` preset with `voyager-maintainers` as reviewer team (timezone Berlin, officeHours, automerge patch, semantic commits, vulnerability alerts)
- Add `minestom` preset for correct date-based versioning of `net.minestom:minestom`
- Add `paper` preset for correct versioning of `io.papermc.paper:paper-api`

Aligns Voyager with the same pattern used in [ManisGame](https://github.com/OneLiteFeatherNET/ManisGame/blob/main/renovate.json).

## What changed

| Removed (now via preset) | Added |
|---|---|
| `config:recommended` | `default(voyager-maintainers)` |
| `:semanticCommitsDisabled` | semantic commits **enabled** (matches Conventional Commits) |
| manual `labels`, `rebaseWhen`, `automerge patch` | `minestom` versioning preset |
| — | `paper` versioning preset |

🤖 Generated with [Claude Code](https://claude.ai/referral/m5Ak2Sa7aQ)