### PR TITLE
feat(skills): add 8 new Claude Code slash-command skills

### DIFF
--- a/.claude/skills/add-translation.md
+++ b/.claude/skills/add-translation.md
@@ -1,0 +1,133 @@
+---
+name: add-translation
+description: Add a new i18n translation key to Voyager correctly, enforcing <arg:N> placeholder syntax.
+---
+# Add Translation
+
+Guide for adding a new user-facing string to Voyager's i18n system. Follows the rules in `docs/guides/how-to-add-a-translation.md` and enforces the `<arg:N>` placeholder format.
+
+## Inputs required
+
+Before starting, collect:
+
+- **Translation key** — must be in the `voyager.` namespace (e.g. `voyager.game.ring.collected`)
+- **English text** — the full string, with placeholders written as `<arg:0>`, `<arg:1>`, etc.
+- **Argument count** — how many runtime values are injected (0 if none)
+- **Usage location** — the Java class and method where `Component.translatable(...)` will be called
+
+## Critical rule — placeholder format
+
+NEVER use `{0}` or `{N}` (MessageFormat syntax). `PluginTranslationRegistry` disables the MessageFormat path, so `{0}` renders as the literal text `{0}` in-game.
+
+ALWAYS use `<arg:N>` (zero-indexed MiniMessage syntax):
+
+```properties
+# CORRECT
+voyager.game.ring.collected=<green>Ring collected! Points: <arg:0>
+
+# WRONG — {0} appears as literal text in-game
+voyager.game.ring.collected=<green>Ring collected! Points: {0}
+```
+
+## Steps
+
+### 1. Add the key to the properties file
+
+Choose the correct file for the module where the string is displayed:
+
+| Module | Properties file |
+|---|---|
+| `server` (game/Minestom) | `server/src/main/resources/elytrarace_en_US.properties` |
+| `plugins/setup` | `plugins/setup/src/main/resources/elytrarace.properties` |
+| `plugins/game` (legacy) | `plugins/game/src/main/resources/elytrarace.properties` |
+
+Append a new line at the end of the appropriate file. Use the `voyager.` key prefix and `<arg:N>` for every placeholder:
+
+```properties
+# No arguments
+voyager.game.ring.collected=<green>Ring collected!
+
+# One argument
+voyager.game.ring.collected=<green>Ring collected! Points: <arg:0>
+
+# Multiple arguments
+voyager.game.ring.collected=<green><arg:0> collected a ring! Points: <arg:1>
+```
+
+Existing keys in `server/src/main/resources/elytrarace_en_US.properties` serve as a style reference:
+
+```properties
+phase.lobby.player.join=<lang:plugin.prefix> <green><arg:0> <white>joined the game (<arg:1>/<arg:2>)
+hud.actionbar=<white>Speed: <arg:0> m/s | Points: <arg:1>
+end.score_line=#<arg:0> <arg:1> — <arg:2> pts
+```
+
+### 2. Use the key in Java
+
+Call `Component.translatable(String key, Component... args)`. Each argument must be a `Component`:
+
+```java
+// No arguments
+Component msg = Component.translatable("voyager.game.ring.collected");
+
+// One argument
+Component msg = Component.translatable("voyager.game.ring.collected",
+    Component.text(points));
+
+// Multiple arguments
+Component msg = Component.translatable("voyager.game.ring.collected",
+    Component.text(playerName),
+    Component.text(points));
+```
+
+### 3. Special render contexts (Paper plugins only)
+
+Two Paper contexts do not use automatic translation and need an explicit `GlobalTranslator.render()` call:
+
+**Inventory titles** (constructed once at creation time):
+
+```java
+Component title = GlobalTranslator.render(
+    Component.translatable("voyager.gui.some.title", arg0),
+    Locale.US
+);
+Inventory inv = Bukkit.createInventory(null, 54, title);
+```
+
+**`TextDisplay` entity labels**:
+
+```java
+textDisplay.customName(GlobalTranslator.render(
+    Component.translatable("voyager.entity.some.label", Component.text(index)),
+    Locale.US
+));
+```
+
+This step is not needed in the `server` (Minestom) module — `MinestomAdventure.AUTOMATIC_COMPONENT_TRANSLATION = true` handles rendering automatically.
+
+### 4. Run the build to verify
+
+```bash
+./gradlew build
+```
+
+A clean build confirms that:
+- The key exists in the properties file (no missing-key warning at runtime)
+- The Java code compiles with the correct `Component.translatable(...)` signature
+- The key-coverage tests (`TranslationKeysCoverageTest`, `SetupTranslationKeysTest`) pass — these tests fail if any value still contains `{N}` syntax
+
+## Output
+
+- One new line in the correct `.properties` file
+- One or more `Component.translatable(...)` call sites in Java
+- A green build with passing translation coverage tests
+
+## Common mistakes to avoid
+
+| Mistake | Correct approach |
+|---|---|
+| `{0}` placeholder | Use `<arg:0>` |
+| Key without `voyager.` prefix | Always start with `voyager.` |
+| Passing a raw `String` as argument | Wrap with `Component.text(value)` |
+| Adding the key to the wrong module's file | Match the file to the module where the string is displayed |
+| Skipping the build step | Always run `./gradlew build` to catch coverage test failures |

--- a/.claude/skills/create-adapter.md
+++ b/.claude/skills/create-adapter.md
@@ -1,0 +1,144 @@
+---
+name: create-adapter
+description: Create a new Gson JsonDeserializer adapter for a JSON-backed domain type. Use when adding new map format fields, cup properties, or component types.
+---
+
+# Create Gson Deserializer Adapter
+
+Guide through creating a Gson `JsonDeserializer` adapter following the ManisGame Rule 8 conventions enforced in this project.
+
+## Input Required
+
+Before starting, collect:
+- **Type name** — the Java type being deserialized (e.g., `Ring`, `CupDefinition`, `PlayerStats`)
+- **Adapter kind** — regular domain adapter or component adapter (determines subpackage)
+- **JSON structure** — list of expected JSON fields and their Java types
+
+## Steps
+
+### 1. Determine the correct subpackage
+
+| Adapter kind | Package | Directory |
+|---|---|---|
+| Regular domain adapter | `net.elytrarace.common.adapter` | `shared/common/src/main/java/net/elytrarace/common/adapter/` |
+| Component adapter | `net.elytrarace.common.adapter.component` | `shared/common/src/main/java/net/elytrarace/common/adapter/component/` |
+
+The class name must follow the pattern `{TypeName}Adapter` (e.g., `RingAdapter`, `TitleComponentAdapter`).
+
+### 2. Create the adapter class
+
+Create `{TypeName}Adapter.java` in the correct directory using this template:
+
+```java
+package net.elytrarace.common.adapter; // or adapter.component
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+
+import java.lang.reflect.Type;
+
+public final class XxxAdapter implements JsonDeserializer<Xxx> {
+
+    @Override
+    public Xxx deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+            throws JsonParseException {
+        JsonObject obj = json.getAsJsonObject();
+        // Extract each field — use context.deserialize() for nested types
+        // e.g. String name = obj.get("name").getAsString();
+        //      int count   = obj.get("count").getAsInt();
+        return new Xxx(/* parsed fields */);
+    }
+}
+```
+
+Rules to follow:
+- The class is `final` — no subclassing.
+- No public constructor needed beyond the implicit default.
+- Use `context.deserialize(element, NestedType.class)` for any nested domain objects rather than inlining manual parsing.
+- Throw `JsonParseException` (not `IllegalArgumentException`) when required fields are missing or invalid.
+
+### 3. Register the adapter on GsonBuilder
+
+Locate where the relevant `GsonBuilder` is configured (usually the service that owns the domain type, e.g., `MapService`, `CupService`, or a dedicated factory). Pass the built `Gson` to `GsonFileHandler`:
+
+```java
+Gson gson = new GsonBuilder()
+        .registerTypeAdapter(Xxx.class, new XxxAdapter())
+        // ... other adapters
+        .create();
+GsonFileHandler handler = new GsonFileHandler(gson);
+```
+
+If no custom `GsonBuilder` exists yet for that service, introduce one now. Do NOT modify the zero-arg `GsonFileHandler()` constructor — it is intentionally left with the default Gson for simple cases.
+
+### 4. Add a `package-info.java` if it does not exist
+
+Every package must declare `@NotNullByDefault`. If `adapter` or `adapter.component` is a new package, create:
+
+```java
+@NotNullByDefault
+package net.elytrarace.common.adapter;
+
+import net.elytrarace.common.annotation.NotNullByDefault;
+```
+
+(Adjust the package declaration for `adapter.component` as needed.)
+
+### 5. Write the JUnit 5 test
+
+Create the test at:
+- Regular: `shared/common/src/test/java/net/elytrarace/common/adapter/{TypeName}AdapterTest.java`
+- Component: `shared/common/src/test/java/net/elytrarace/common/adapter/component/{TypeName}AdapterTest.java`
+
+Minimum test coverage:
+
+```java
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class XxxAdapterTest {
+
+    private final Gson gson = new GsonBuilder()
+            .registerTypeAdapter(Xxx.class, new XxxAdapter())
+            .create();
+
+    @Test
+    void deserialize_validJson_returnsExpectedObject() {
+        String json = """
+                {
+                  "field1": "value1",
+                  "field2": 42
+                }
+                """;
+        Xxx result = gson.fromJson(json, Xxx.class);
+        assertThat(result.field1()).isEqualTo("value1");
+        assertThat(result.field2()).isEqualTo(42);
+    }
+
+    @Test
+    void deserialize_missingRequiredField_throwsJsonParseException() {
+        String json = "{}";
+        assertThatThrownBy(() -> gson.fromJson(json, Xxx.class))
+                .isInstanceOf(com.google.gson.JsonParseException.class);
+    }
+}
+```
+
+### 6. Verify with /build
+
+Run `/build` to confirm compilation succeeds and the new test passes.
+
+## Output
+
+- `{TypeName}Adapter.java` in the correct `adapter` or `adapter.component` subpackage
+- `{TypeName}AdapterTest.java` with happy-path and error-path coverage
+- Updated `GsonBuilder` registration in the owning service
+- `package-info.java` if the package is new
+- Clean build with all tests green

--- a/.claude/skills/create-phase.md
+++ b/.claude/skills/create-phase.md
@@ -1,0 +1,241 @@
+---
+name: create-phase
+description: Scaffold a new game phase for the Minestom server. Use when extending the game flow (e.g., Countdown, Results, Intermission).
+---
+
+# Create Game Phase
+
+Add a new phase to the Minestom server game flow following project conventions.
+
+## Input
+
+- Phase name (e.g., "Countdown", "Results", "Intermission")
+- Phase position in the sequence relative to the existing flow (Lobby -> Game -> End)
+- What happens in `onStart()` and `onFinish()`
+- Whether the phase is time-based (`TimedPhase`) or tick-driven (`TickingPhase`)
+
+## Decision: Which base class to extend?
+
+| Base class | When to use |
+|---|---|
+| `TimedPhase` | Phase counts down or up over a fixed duration and auto-finishes (e.g., Lobby, End) |
+| `TickingPhase` | Phase runs every tick indefinitely until code calls `finish()` (e.g., Game) |
+
+Both live in `net.theevilreaper.xerus.api.phase`. Read `MinestomLobbyPhase` for a `TimedPhase` example and `MinestomGamePhase` for a `TickingPhase` example before writing new code.
+
+## Steps
+
+### 1. Read existing phases to understand the pattern
+
+Read at least one of these before writing any code:
+
+- `/mnt/projects/oss/onelitefeather/Voyager/server/src/main/java/net/elytrarace/server/phase/MinestomLobbyPhase.java` — `TimedPhase` example (countdown, actionbar UI)
+- `/mnt/projects/oss/onelitefeather/Voyager/server/src/main/java/net/elytrarace/server/phase/MinestomEndPhase.java` — `TimedPhase` example (results display, server stop)
+- `/mnt/projects/oss/onelitefeather/Voyager/server/src/main/java/net/elytrarace/server/phase/MinestomGamePhase.java` — `TickingPhase` example (ECS loop, manual finish condition)
+
+Also read `GamePhaseFactory` before registering:
+
+- `/mnt/projects/oss/onelitefeather/Voyager/server/src/main/java/net/elytrarace/server/phase/GamePhaseFactory.java`
+
+### 2. Create the phase file
+
+Path: `server/src/main/java/net/elytrarace/server/phase/Minestom{Name}Phase.java`
+
+**TimedPhase template** (countdown that auto-finishes):
+
+```java
+package net.elytrarace.server.phase;
+
+import net.minestom.server.utils.time.TimeUnit;
+import net.theevilreaper.xerus.api.phase.TickDirection;
+import net.theevilreaper.xerus.api.phase.TimedPhase;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+// One-line comment here only if the phase purpose is non-obvious.
+public final class Minestom{Name}Phase extends TimedPhase {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(Minestom{Name}Phase.class);
+    private static final int DEFAULT_{NAME}_TICKS = /* sensible default */;
+
+    private final int durationTicks;
+    private final Runnable onFinishCallback;
+    private boolean finishing = false;
+
+    public Minestom{Name}Phase() {
+        this(DEFAULT_{NAME}_TICKS, null);
+    }
+
+    public Minestom{Name}Phase(int durationTicks, Runnable onFinishCallback) {
+        super("{name}", TimeUnit.SERVER_TICK, 20);
+        this.durationTicks = durationTicks;
+        this.onFinishCallback = onFinishCallback;
+        setEndTicks(0);
+        setCurrentTicks(durationTicks);
+        setTickDirection(TickDirection.DOWN);
+    }
+
+    @Override
+    public void onStart() {
+        finishing = false;
+        setCurrentTicks(durationTicks);
+        super.onStart();
+        LOGGER.info("{Name} phase started — duration {} ticks", durationTicks);
+    }
+
+    @Override
+    public void onUpdate() {
+        PhaseUiHelper.broadcastTimeActionBar("phase.{name}.time", getCurrentTicks());
+    }
+
+    @Override
+    public void finish() {
+        if (finishing) return;
+        finishing = true;
+        super.finish();
+    }
+
+    @Override
+    protected void onFinish() {
+        LOGGER.info("{Name} phase finished");
+        if (onFinishCallback != null) {
+            onFinishCallback.run();
+        }
+    }
+}
+```
+
+**TickingPhase template** (runs every tick, finishes on a condition):
+
+```java
+package net.elytrarace.server.phase;
+
+import net.minestom.server.utils.time.TimeUnit;
+import net.theevilreaper.xerus.api.phase.TickingPhase;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+// One-line comment here only if the phase purpose is non-obvious.
+public final class Minestom{Name}Phase extends TickingPhase {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(Minestom{Name}Phase.class);
+
+    private final Runnable onFinishCallback;
+    private boolean finishing = false;
+
+    public Minestom{Name}Phase(Runnable onFinishCallback) {
+        super("{name}", TimeUnit.SERVER_TICK, 1);
+        this.onFinishCallback = onFinishCallback;
+    }
+
+    @Override
+    public void onStart() {
+        finishing = false;
+        super.onStart();
+        LOGGER.info("{Name} phase started");
+    }
+
+    @Override
+    public void onUpdate() {
+        // Per-tick logic here. Call finish() when the exit condition is met.
+        if (/* exit condition */) {
+            finish();
+        }
+    }
+
+    @Override
+    public void finish() {
+        if (finishing) return;
+        finishing = true;
+        LOGGER.info("{Name} phase finished");
+        if (onFinishCallback != null) {
+            onFinishCallback.run();
+        }
+        super.finish();
+    }
+}
+```
+
+### 3. Register the phase in GamePhaseFactory
+
+Open `/mnt/projects/oss/onelitefeather/Voyager/server/src/main/java/net/elytrarace/server/phase/GamePhaseFactory.java`.
+
+Add the new phase to the `List.of(...)` in the appropriate position inside `createGamePhases(...)`. Preserve the existing phase order and add overloaded factory methods if the new phase requires additional constructor arguments.
+
+Example — inserting a `Countdown` phase between Lobby and Game:
+
+```java
+var lobby = new MinestomLobbyPhase(120, onMapSwitch);
+var countdown = new MinestomCountdownPhase(60, /* callback */);  // new
+var game = new MinestomGamePhase(entityManager,
+        MinestomGamePhase.DEFAULT_RACE_DURATION_TICKS, onGamePhaseFinished);
+var end = new MinestomEndPhase(100, entityManager, gameResultPersistence);
+return new LinearPhaseSeries<>("game-phases", List.of(lobby, countdown, game, end));
+```
+
+Update the `@param` Javadoc of the factory method to document any new callback parameter.
+
+### 4. Write JUnit 5 tests
+
+Path: `server/src/test/java/net/elytrarace/server/phase/Minestom{Name}PhaseTest.java`
+
+Minimum test coverage:
+
+```java
+package net.elytrarace.server.phase;
+
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class Minestom{Name}PhaseTest {
+
+    @Test
+    void phaseNameIsCorrect() {
+        var phase = new Minestom{Name}Phase();
+        assertThat(phase.getName()).isEqualTo("{name}");
+    }
+
+    @Test
+    void onStartCallbackIsInvokedOnFinish() {
+        var[] called = {false};
+        var phase = new Minestom{Name}Phase(/* ticks */, () -> called[0] = true);
+        phase.onStart();
+        phase.finish();
+        assertThat(called[0]).isTrue();
+    }
+
+    @Test
+    void finishIsIdempotent() {
+        var[] count = {0};
+        var phase = new Minestom{Name}Phase(/* ticks */, () -> count[0]++);
+        phase.onStart();
+        phase.finish();
+        phase.finish();
+        assertThat(count[0]).isEqualTo(1);
+    }
+}
+```
+
+Also update `GamePhaseFactoryTest` to assert the new phase appears in the series at the correct index.
+
+### 5. Build and verify
+
+Run `/build` and confirm there are no compilation errors or test failures.
+
+## Rules
+
+- Class naming is always `Minestom{Name}Phase` — no exceptions.
+- Package is always `net.elytrarace.server.phase`.
+- Never import `org.bukkit.*` — this is a Minestom server module.
+- The `finishing` guard (`if (finishing) return;`) is mandatory in every `finish()` override to prevent double-execution during phase transitions.
+- Use `PhaseUiHelper.broadcastTimeActionBar(key, ticks)` for actionbar countdowns — do not call `player.sendActionBar(...)` directly in phase code.
+- User-facing strings use `Component.translatable("phase.{name}.something")` — never hardcoded English text.
+- Every new phase must be registered in `GamePhaseFactory` before the skill is considered done.
+- Add a class-level Javadoc comment only when the phase purpose is not obvious from its name and the template comment above.
+
+## Output
+
+- `server/src/main/java/net/elytrarace/server/phase/Minestom{Name}Phase.java`
+- Updated `server/src/main/java/net/elytrarace/server/phase/GamePhaseFactory.java`
+- `server/src/test/java/net/elytrarace/server/phase/Minestom{Name}PhaseTest.java`
+- Updated `server/src/test/java/net/elytrarace/server/phase/GamePhaseFactoryTest.java`

--- a/.claude/skills/create-pr.md
+++ b/.claude/skills/create-pr.md
@@ -1,17 +1,18 @@
 ---
 name: create-pr
-description: Create a GitHub PR targeting master with the correct PR template, a Conventional Commits title, and the project referral footer.
+description: Create a GitHub PR targeting main with the correct PR template, a Conventional Commits title, and the project referral footer.
 ---
 
 # Create PR
 
-Open a GitHub pull request for the current branch against `master`, following the project PR template and Conventional Commits conventions.
+Open a GitHub pull request for the current branch against `main`, following the project PR template and Conventional Commits conventions.
 
 ## Rules
 
-- Base branch is always `master` — never `main` or any other branch.
+- Base branch is always `main`.
 - PR title MUST follow Conventional Commits: `type(scope): short description` (e.g. `feat(server): add ring boost system`).
 - Never force-push (`git push --force` / `git push -f`) under any circumstances.
+- The PR body MUST be written in **English** — never German, even though the template headings are in German.
 - The PR body MUST follow the template structure from `.github/pull_request_template.md` (reproduced below).
 - The footer of the PR body must include the referral link `https://claude.ai/referral/m5Ak2Sa7aQ`.
 - Agent team members Compass, Scribe, Lumen, and Pulse are always involved in significant changes — mention their involvement in the PR body where relevant.
@@ -22,13 +23,13 @@ Open a GitHub pull request for the current branch against `master`, following th
 ```bash
 git branch --show-current
 ```
-If the result is `master` or `main`, stop and ask the user which feature branch to use.
+If the result is `main`, stop and ask the user which feature branch to use.
 
 2. Summarise the commits that will be included in the PR:
 ```bash
-git log --oneline master..HEAD
+git log --oneline origin/main..HEAD
 ```
-Use this list to inform the PR title and the "Was wurde geändert?" section.
+Use this list to inform the PR title and the "What changed?" section.
 
 3. Check whether a push is needed:
 ```bash
@@ -40,45 +41,45 @@ git status
 git push -u origin <branch-name>
 ```
 
-5. Read `.github/pull_request_template.md` to confirm the current template structure. The template currently looks like this (use it as the body skeleton):
+5. Read `.github/pull_request_template.md` to confirm the current template structure. Use it as the body skeleton, but **write all content in English**:
 
 ```
-## Was wurde geändert?
+## What changed?
 
-<!-- Kurze Beschreibung der Änderung -->
+<!-- Short description of the change -->
 
-## Typ
+## Type
 
-- [ ] `feat:` — neues Feature
-- [ ] `fix:` — Bugfix
-- [ ] `refactor:` — Refactoring ohne Verhaltensänderung
-- [ ] `chore:` — Pflege/Tooling
-- [ ] `docs:` — nur Dokumentation
-- [ ] `test:` — nur Tests
-- [ ] `ci:` — CI/CD-Änderungen
+- [ ] `feat:` — new feature
+- [ ] `fix:` — bug fix
+- [ ] `refactor:` — refactoring without behaviour change
+- [ ] `chore:` — maintenance/tooling
+- [ ] `docs:` — documentation only
+- [ ] `test:` — tests only
+- [ ] `ci:` — CI/CD changes
 
 ## Checklist
 
-- [ ] PR-Titel folgt Conventional Commits (`fix(scope): beschreibung`)
-- [ ] Tests vorhanden und grün
-- [ ] Kein neuer Code ohne Test
-- [ ] Breaking Change? → `feat!:` oder `BREAKING CHANGE:` im Commit-Footer
+- [ ] PR title follows Conventional Commits (`fix(scope): description`)
+- [ ] Tests present and passing
+- [ ] No new code without tests
+- [ ] Breaking change? → `feat!:` or `BREAKING CHANGE:` in commit footer
 ```
 
-6. Compose the full PR body:
-   - Fill in "Was wurde geändert?" with a concise summary derived from the commit list.
-   - Check the correct "Typ" checkbox that matches the Conventional Commits type of the changes.
+6. Compose the full PR body in **English**:
+   - Fill in "What changed?" with a concise summary derived from the commit list.
+   - Check the correct "Type" checkbox that matches the Conventional Commits type of the changes.
    - Leave the Checklist items unchecked (the author fills them in).
    - Append the following footer after the checklist (separated by a blank line):
 
 ```
 ---
-Created with [Claude Code](https://claude.ai/referral/m5Ak2Sa7aQ)
+Generated with [Claude Code](https://claude.ai/referral/m5Ak2Sa7aQ)
 ```
 
 7. Create the PR:
 ```bash
-gh pr create --base master --title "<type(scope): description>" --body "<full body from step 6>"
+gh pr create --base main --title "<type(scope): description>" --body "<full body from step 6>"
 ```
 
 8. Display the PR URL returned by `gh pr create` so the user can open it immediately.

--- a/.claude/skills/create-pr.md
+++ b/.claude/skills/create-pr.md
@@ -1,0 +1,89 @@
+---
+name: create-pr
+description: Create a GitHub PR targeting master with the correct PR template, a Conventional Commits title, and the project referral footer.
+---
+
+# Create PR
+
+Open a GitHub pull request for the current branch against `master`, following the project PR template and Conventional Commits conventions.
+
+## Rules
+
+- Base branch is always `master` — never `main` or any other branch.
+- PR title MUST follow Conventional Commits: `type(scope): short description` (e.g. `feat(server): add ring boost system`).
+- Never force-push (`git push --force` / `git push -f`) under any circumstances.
+- The PR body MUST follow the template structure from `.github/pull_request_template.md` (reproduced below).
+- The footer of the PR body must include the referral link `https://claude.ai/referral/m5Ak2Sa7aQ`.
+- Agent team members Compass, Scribe, Lumen, and Pulse are always involved in significant changes — mention their involvement in the PR body where relevant.
+
+## Steps
+
+1. Check the current branch:
+```bash
+git branch --show-current
+```
+If the result is `master` or `main`, stop and ask the user which feature branch to use.
+
+2. Summarise the commits that will be included in the PR:
+```bash
+git log --oneline master..HEAD
+```
+Use this list to inform the PR title and the "Was wurde geändert?" section.
+
+3. Check whether a push is needed:
+```bash
+git status
+```
+
+4. If the branch has not been pushed yet, push it (never force-push):
+```bash
+git push -u origin <branch-name>
+```
+
+5. Read `.github/pull_request_template.md` to confirm the current template structure. The template currently looks like this (use it as the body skeleton):
+
+```
+## Was wurde geändert?
+
+<!-- Kurze Beschreibung der Änderung -->
+
+## Typ
+
+- [ ] `feat:` — neues Feature
+- [ ] `fix:` — Bugfix
+- [ ] `refactor:` — Refactoring ohne Verhaltensänderung
+- [ ] `chore:` — Pflege/Tooling
+- [ ] `docs:` — nur Dokumentation
+- [ ] `test:` — nur Tests
+- [ ] `ci:` — CI/CD-Änderungen
+
+## Checklist
+
+- [ ] PR-Titel folgt Conventional Commits (`fix(scope): beschreibung`)
+- [ ] Tests vorhanden und grün
+- [ ] Kein neuer Code ohne Test
+- [ ] Breaking Change? → `feat!:` oder `BREAKING CHANGE:` im Commit-Footer
+```
+
+6. Compose the full PR body:
+   - Fill in "Was wurde geändert?" with a concise summary derived from the commit list.
+   - Check the correct "Typ" checkbox that matches the Conventional Commits type of the changes.
+   - Leave the Checklist items unchecked (the author fills them in).
+   - Append the following footer after the checklist (separated by a blank line):
+
+```
+---
+Created with [Claude Code](https://claude.ai/referral/m5Ak2Sa7aQ)
+```
+
+7. Create the PR:
+```bash
+gh pr create --base master --title "<type(scope): description>" --body "<full body from step 6>"
+```
+
+8. Display the PR URL returned by `gh pr create` so the user can open it immediately.
+
+## Output
+
+- The URL of the newly created PR.
+- A reminder to tick off the checklist items in the PR description on GitHub.

--- a/.claude/skills/create-pr.md
+++ b/.claude/skills/create-pr.md
@@ -1,6 +1,6 @@
 ---
 name: create-pr
-description: Create a GitHub PR targeting main with the correct PR template, a Conventional Commits title, and the project referral footer.
+description: Create a GitHub PR targeting main with labels, milestone, project assignment, related issue references, a Conventional Commits title, and the project referral footer.
 ---
 
 # Create PR
@@ -82,9 +82,54 @@ Generated with [Claude Code](https://claude.ai/referral/m5Ak2Sa7aQ)
 gh pr create --base main --title "<type(scope): description>" --body "<full body from step 6>"
 ```
 
-8. Display the PR URL returned by `gh pr create` so the user can open it immediately.
+8. Add labels. Fetch available labels first, then pick all that apply:
+```bash
+gh label list --repo OneLiteFeatherNET/Voyager
+```
+Label mapping by Conventional Commits type:
+- `feat:` → `enhancement`
+- `fix:` → `bug`
+- `docs:` → `documentation`
+- `chore:` / `ci:` → `technic`
+- `refactor:` / `test:` → `cleanup` or `testing`
+- Always add domain labels if applicable: `gameplay`, `database`, `infrastructure`, `setup`
+- Add priority labels if known: `P0`, `P1`, `P2`
+```bash
+gh pr edit <number> --add-label "<label1>,<label2>"
+```
+
+9. Assign the correct milestone. Fetch available milestones first:
+```bash
+gh api repos/OneLiteFeatherNET/Voyager/milestones --jq '.[] | "\(.number)\t\(.title)"'
+```
+Pick the earliest active milestone the PR contributes to (e.g. `Alpha v0.1` before `Beta v0.2`):
+```bash
+gh pr edit <number> --milestone "<milestone title>"
+```
+
+10. Add the PR to the Voyager Roadmap project (project ID 19):
+```bash
+gh project item-add 19 --owner OneLiteFeatherNET --url "<pr-url>"
+```
+
+11. Find related open issues and reference them in the PR body. Search for issues whose topic overlaps with the changes:
+```bash
+gh issue list --repo OneLiteFeatherNET/Voyager --state open --limit 50
+```
+- If this PR **closes** an issue, add `Closes #N` to the PR body (GitHub will auto-close it on merge).
+- If this PR **supports but does not close** an issue, add a "Related issues" section with plain `#N` references and a one-line explanation of the relationship.
+- If no issues are related, omit the section entirely — do not add empty placeholders.
+
+Update the PR body with the issue references:
+```bash
+gh pr edit <number> --body "<updated body with issue references>"
+```
+
+12. Display the final PR URL so the user can open it immediately.
 
 ## Output
 
 - The URL of the newly created PR.
+- Labels, milestone, and project applied.
+- Any related issues referenced in the body.
 - A reminder to tick off the checklist items in the PR description on GitHub.

--- a/.claude/skills/create-repository.md
+++ b/.claude/skills/create-repository.md
@@ -1,0 +1,292 @@
+---
+name: create-repository
+description: Scaffold a new Hibernate repository in shared/database following the sealed-interface + DefaultImpl pattern.
+---
+
+# Create Hibernate Repository
+
+Scaffold a new Hibernate ORM repository in `shared/database` following the ManisGame sealed-interface pattern exactly.
+
+## Input
+
+Collect the following before starting:
+
+- **Entity/domain name** (e.g., `PlayerStats`, `CupResult`) — used to derive all file names
+- **Fields and their types** — used for the `@Entity` class
+- **Key query methods needed** — e.g., `findByPlayerId(UUID playerId)`, `findAll()`
+
+## Steps
+
+### 1. Create the entity class
+
+File: `shared/database/src/main/java/net/elytrarace/database/entity/{Name}.java`
+
+```java
+package net.elytrarace.database.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "{table_name}")         // snake_case plural, e.g. "player_stats"
+public class {Name} {
+
+    @Id
+    @Column(name = "id", nullable = false, updatable = false)
+    private {IdType} id;              // typically UUID or Long
+
+    // Add annotated fields here, e.g.:
+    // @Column(name = "player_id", nullable = false)
+    // private UUID playerId;
+
+    protected {Name}() {}             // required no-arg constructor for Hibernate
+
+    public {Name}({IdType} id /*, other fields */) {
+        this.id = id;
+    }
+
+    public {IdType} getId() { return id; }
+
+    // Getters for each field — NO public setters unless update operations are needed
+}
+```
+
+Rules for entities:
+- No-arg constructor must be `protected` (Hibernate only).
+- Prefer immutable fields; add setters only when the repository update path needs them.
+- UUID primary keys: add `@Column(columnDefinition = "CHAR(36)")` for MariaDB compatibility.
+- Use `@Column(nullable = false)` on every field that must be NOT NULL in the schema.
+
+### 2. Check / create `package-info.java` for the entity package
+
+File: `shared/database/src/main/java/net/elytrarace/database/entity/package-info.java`
+
+```java
+@NotNullByDefault
+package net.elytrarace.database.entity;
+
+import org.jetbrains.annotations.NotNullByDefault;
+```
+
+Only create this file if it does not already exist.
+
+### 3. Create the sealed repository interface
+
+File: `shared/database/src/main/java/net/elytrarace/database/repository/{Name}Repository.java`
+
+```java
+package net.elytrarace.database.repository;
+
+import net.elytrarace.database.entity.{Name};
+import org.hibernate.SessionFactory;
+
+import java.util.List;
+import java.util.Optional;
+
+public sealed interface {Name}Repository permits Default{Name}Repository {
+
+    /**
+     * Creates a new repository backed by the given SessionFactory.
+     */
+    static {Name}Repository create(SessionFactory sessionFactory) {
+        return new Default{Name}Repository(sessionFactory);
+    }
+
+    // --- declare query methods here, examples:
+
+    Optional<{Name}> findById({IdType} id);
+
+    List<{Name}> findAll();
+
+    void save({Name} entity);
+
+    void delete({IdType} id);
+}
+```
+
+Rules:
+- The interface is `sealed` and names only `Default{Name}Repository` in `permits`.
+- The static `create(SessionFactory)` factory is the only way callers obtain an instance.
+- Methods return `Optional<T>` for single-result queries that may find nothing.
+- Collections are `List<T>`; never return raw arrays.
+- No checked exceptions — let Hibernate runtime exceptions propagate.
+
+### 4. Check / create `package-info.java` for the repository package
+
+File: `shared/database/src/main/java/net/elytrarace/database/repository/package-info.java`
+
+```java
+@NotNullByDefault
+package net.elytrarace.database.repository;
+
+import org.jetbrains.annotations.NotNullByDefault;
+```
+
+Only create this file if it does not already exist.
+
+### 5. Create the `Default{Name}Repository` implementation
+
+File: `shared/database/src/main/java/net/elytrarace/database/repository/Default{Name}Repository.java`
+
+```java
+package net.elytrarace.database.repository;
+
+import net.elytrarace.database.entity.{Name};
+import org.hibernate.SessionFactory;
+
+import java.util.List;
+import java.util.Optional;
+
+public final class Default{Name}Repository implements {Name}Repository {
+
+    private final SessionFactory sessionFactory;
+
+    Default{Name}Repository(SessionFactory sessionFactory) {    // package-private — use factory method
+        this.sessionFactory = sessionFactory;
+    }
+
+    @Override
+    public Optional<{Name}> findById({IdType} id) {
+        try (var session = sessionFactory.openSession()) {
+            return Optional.ofNullable(session.get({Name}.class, id));
+        }
+    }
+
+    @Override
+    public List<{Name}> findAll() {
+        try (var session = sessionFactory.openSession()) {
+            return session.createQuery("FROM {Name}", {Name}.class).list();
+        }
+    }
+
+    @Override
+    public void save({Name} entity) {
+        var transaction = sessionFactory.getCurrentSession().beginTransaction();
+        try (var session = sessionFactory.openSession()) {
+            session.persist(entity);
+            session.getTransaction().commit();
+        }
+    }
+
+    @Override
+    public void delete({IdType} id) {
+        try (var session = sessionFactory.openSession()) {
+            var tx = session.beginTransaction();
+            var entity = session.get({Name}.class, id);
+            if (entity != null) {
+                session.remove(entity);
+            }
+            tx.commit();
+        }
+    }
+}
+```
+
+Rules:
+- Constructor is package-private; callers use `{Name}Repository.create(sessionFactory)`.
+- Always open a new `Session` per method via `sessionFactory.openSession()` inside a try-with-resources block.
+- Wrap write operations (save, delete) in explicit transactions: `session.beginTransaction()` / `tx.commit()`.
+- Roll back on exceptions: add `catch (Exception e) { tx.rollback(); throw e; }` to write methods.
+- Use HQL (`FROM {Name}`) not raw SQL unless a native query is necessary.
+
+### 6. Register the entity with Hibernate
+
+Open the Hibernate configuration class / `SessionFactory` builder in `shared/database` (or in the module that initializes the database) and add the new entity class:
+
+```java
+configuration.addAnnotatedClass({Name}.class);
+```
+
+If no central configuration exists yet, create one and document it. Do not skip this step — Hibernate will not see the entity otherwise.
+
+### 7. Write a JUnit 5 test
+
+File: `shared/database/src/test/java/net/elytrarace/database/repository/{Name}RepositoryTest.java`
+
+Use Mockito to mock `SessionFactory` and `Session` for unit tests, or an embedded H2 database for integration tests. The build only ships `mariadb` at runtime, so H2 must be added as `testImplementation` if used.
+
+Minimal test structure:
+
+```java
+package net.elytrarace.database.repository;
+
+import net.elytrarace.database.entity.{Name};
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+class {Name}RepositoryTest {
+
+    private SessionFactory sessionFactory;
+    private Session session;
+    private {Name}Repository repository;
+
+    @BeforeEach
+    void setUp() {
+        sessionFactory = mock(SessionFactory.class);
+        session = mock(Session.class);
+        when(sessionFactory.openSession()).thenReturn(session);
+        repository = {Name}Repository.create(sessionFactory);
+    }
+
+    @Test
+    void findById_returnsEmpty_whenEntityDoesNotExist() {
+        when(session.get({Name}.class, /* test id */)).thenReturn(null);
+        Optional<{Name}> result = repository.findById(/* test id */);
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void findById_returnsEntity_whenEntityExists() {
+        var entity = new {Name}(/* test id, fields */);
+        when(session.get({Name}.class, /* test id */)).thenReturn(entity);
+        Optional<{Name}> result = repository.findById(/* test id */);
+        assertThat(result).contains(entity);
+    }
+
+    // Add tests for each declared query method
+}
+```
+
+Add Mockito as `testImplementation` to `shared/database/build.gradle.kts` if not already present:
+
+```kotlin
+testImplementation("org.mockito:mockito-core:5.+")
+```
+
+### 8. Build and verify
+
+Run:
+
+```bash
+./gradlew :shared:database:build
+```
+
+Resolve all compilation errors before declaring the skill done.
+
+## Output
+
+- `shared/database/src/main/java/net/elytrarace/database/entity/{Name}.java`
+- `shared/database/src/main/java/net/elytrarace/database/entity/package-info.java` (if new)
+- `shared/database/src/main/java/net/elytrarace/database/repository/{Name}Repository.java`
+- `shared/database/src/main/java/net/elytrarace/database/repository/Default{Name}Repository.java`
+- `shared/database/src/main/java/net/elytrarace/database/repository/package-info.java` (if new)
+- `shared/database/src/test/java/net/elytrarace/database/repository/{Name}RepositoryTest.java`
+- Updated Hibernate configuration with `addAnnotatedClass({Name}.class)`
+
+## Invariants (never break these)
+
+- The interface is `sealed`; the implementation is `final` and package-private-constructed.
+- `Default{Name}Repository` constructor is **package-private** — never `public`.
+- Every package has a `package-info.java` annotated with `@NotNullByDefault`.
+- `shared/database` must NOT import `net.minestom.*` or `org.bukkit.*`.
+- `Optional` for nullable single results; `List` for collections.
+- All write operations are wrapped in explicit Hibernate transactions with rollback on failure.

--- a/.claude/skills/create-service.md
+++ b/.claude/skills/create-service.md
@@ -1,0 +1,180 @@
+---
+name: create-service
+description: Scaffold a new domain service (sealed interface + DefaultImpl + JUnit 5 test). Use for every new service in the server or shared modules.
+---
+
+# Create Domain Service
+
+Scaffold a new service following Voyager's ManisGame design rules: sealed interface, `DefaultXxx` final implementation, static `create()` factory, and a JUnit 5 test class.
+
+## Input
+
+- Service name (e.g., "Scoring", "Cup", "Player")
+- Module — defaults to `server`; use `shared/common` only for platform-agnostic services
+- Domain subpackage (e.g., "scoring", "cup", "player")
+- Key methods to expose on the interface (name, parameters, return type)
+
+## Steps
+
+### 1. Determine file paths
+
+Given service name `{Name}`, module `{module}`, and subpackage `{domain}`:
+
+- Interface:  `{module}/src/main/java/net/elytrarace/{moduleShort}/{domain}/{Name}Service.java`
+- Impl:       `{module}/src/main/java/net/elytrarace/{moduleShort}/{domain}/Default{Name}Service.java`
+- Test:       `{module}/src/test/java/net/elytrarace/{moduleShort}/{domain}/{Name}ServiceTest.java`
+- Pkg-info:   `{module}/src/main/java/net/elytrarace/{moduleShort}/{domain}/package-info.java`
+
+Where `{moduleShort}` is:
+- `server` module → `server`
+- `shared/common` module → `common`
+
+### 2. Create the sealed interface
+
+```java
+package net.elytrarace.{moduleShort}.{domain};
+
+import org.jetbrains.annotations.Contract;
+import java.util.Collection;
+import org.jetbrains.annotations.Unmodifiable;
+
+public sealed interface {Name}Service permits Default{Name}Service {
+
+    @Contract(pure = true)
+    static {Name}Service create() {
+        return new Default{Name}Service();
+    }
+
+    // Add declared key methods here, e.g.:
+    // boolean register(SomeThing thing);
+    // @Unmodifiable Collection<SomeThing> getAll();
+    // void remove(SomeThing thing);
+}
+```
+
+Rules:
+- `sealed` + `permits Default{Name}Service` — no other permits clause
+- Static `create()` is the only public factory; no public constructor on the impl
+- Return `@Unmodifiable` collections from any list/collection accessor
+
+### 3. Create the `Default{Name}Service` final implementation
+
+```java
+package net.elytrarace.{moduleShort}.{domain};
+
+import org.jetbrains.annotations.Unmodifiable;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.Map;
+
+public final class Default{Name}Service implements {Name}Service {
+
+    // Use ConcurrentHashMap as backing store
+    private final Map<KeyType, ValueType> store = new ConcurrentHashMap<>();
+
+    // Implement every method declared on the interface
+    // Return Collections.unmodifiableCollection(...) for collection accessors
+}
+```
+
+Rules:
+- `final` class — never extend it
+- Backing storage: `ConcurrentHashMap` (thread-safe, no explicit synchronization)
+- Wrap return values with `Collections.unmodifiableCollection()` / `Collections.unmodifiableMap()` etc.
+- No Bukkit (`org.bukkit.*`) or Paper (`io.papermc.*`) imports — forbidden in `server` and `shared` modules
+
+### 4. Check or create `package-info.java`
+
+If `package-info.java` does not already exist for the target package, create it:
+
+```java
+@NotNullByDefault
+package net.elytrarace.{moduleShort}.{domain};
+
+import org.jetbrains.annotations.NotNullByDefault;
+```
+
+### 5. Create the JUnit 5 test class
+
+```java
+package net.elytrarace.{moduleShort}.{domain};
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class {Name}ServiceTest {
+
+    private {Name}Service service;
+
+    @BeforeEach
+    void setUp() {
+        // Given
+        service = {Name}Service.create();
+    }
+
+    @Test
+    void shouldReturnEmptyCollectionInitially() {
+        // When
+        var result = service.getAll(); // adjust to actual method name
+
+        // Then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void shouldRegisterEntry() {
+        // Given
+        var entry = /* build a test entry */;
+
+        // When
+        service.register(entry); // adjust to actual method name
+
+        // Then
+        assertThat(service.getAll()).containsExactly(entry);
+    }
+
+    // Add negative tests: duplicates, nulls, removal, thread-safety if needed
+}
+```
+
+Rules:
+- Use JUnit 5 (`@Test`, `@BeforeEach`) — no JUnit 4
+- Use AssertJ for assertions (`assertThat(...)`) — no Hamcrest, no `assertEquals`
+- Structure every test: Given / When / Then (comments required)
+- Instantiate via `{Name}Service.create()` in `setUp()`, never `new Default{Name}Service()`
+- Include at least: empty-state test, happy-path register test, and one edge-case test
+
+### 6. Verify compilation
+
+Run the build to confirm all new files compile without errors:
+
+```
+/build
+```
+
+Fix any compilation errors before declaring the skill complete.
+
+## Rules Summary
+
+| Rule | Requirement |
+|---|---|
+| Interface modifier | `public sealed interface {Name}Service permits Default{Name}Service` |
+| Impl modifier | `public final class Default{Name}Service implements {Name}Service` |
+| Factory | `static {Name}Service create()` on the interface, returning `new Default{Name}Service()` |
+| Backing storage | `ConcurrentHashMap` — always |
+| Collection return | Wrap with `@Unmodifiable` + `Collections.unmodifiable*()` |
+| Forbidden imports | `org.bukkit.*` and `io.papermc.*` in `server` and `shared` modules |
+| Package annotation | `@NotNullByDefault` in `package-info.java` for every new package |
+| Test framework | JUnit 5 + AssertJ, Given-When-Then structure |
+| Test instantiation | Always via `{Name}Service.create()` — never `new Default{Name}Service()` |
+
+## Output
+
+- `{Name}Service.java` — sealed interface with `create()` factory and declared methods
+- `Default{Name}Service.java` — final implementation backed by `ConcurrentHashMap`
+- `package-info.java` — `@NotNullByDefault` annotation (created if missing)
+- `{Name}ServiceTest.java` — JUnit 5 test with at least three test cases
+- Build passes with no errors

--- a/.claude/skills/db-start.md
+++ b/.claude/skills/db-start.md
@@ -1,0 +1,49 @@
+---
+name: db-start
+description: Start the MariaDB Docker container for local development, check health, and show connection info.
+---
+
+# Start Development Database
+
+Start the Voyager MariaDB container, verify it is healthy, and display connection details.
+
+## Steps
+
+1. Check if the container is already running:
+```bash
+docker compose -f /mnt/projects/oss/onelitefeather/Voyager/docker/mariadb/compose.yml ps
+```
+If the `voyager-mariadb` container already shows `running`, skip step 2 and go straight to step 4.
+
+2. If not running, start the container:
+```bash
+docker compose -f /mnt/projects/oss/onelitefeather/Voyager/docker/mariadb/compose.yml up -d
+```
+
+3. Show the last log lines to confirm the server is ready:
+```bash
+docker compose -f /mnt/projects/oss/onelitefeather/Voyager/docker/mariadb/compose.yml logs --tail=5
+```
+Look for `ready for connections` in the output. If the container is still initialising, wait a few seconds and repeat.
+
+4. Report the connection details to the user:
+
+| Property  | Value             |
+|-----------|-------------------|
+| Host      | `localhost`       |
+| Port      | `3306`            |
+| Database  | `voyager-project` |
+| User      | `voyager-project` |
+| Password  | `voyager-project` |
+
+5. Remind the user of the stop command:
+```bash
+docker compose -f /mnt/projects/oss/onelitefeather/Voyager/docker/mariadb/compose.yml down
+```
+
+## Output
+
+- Whether the container was already running or was freshly started
+- Last 5 log lines confirming readiness
+- Connection details table
+- Stop command for reference

--- a/.claude/skills/health-check.md
+++ b/.claude/skills/health-check.md
@@ -1,0 +1,101 @@
+---
+name: health-check
+description: Full project health check — build, tests, ArchUnit, import isolation, migration status. Produces a single GREEN/RED report.
+---
+
+# Project Health Check
+
+Run a comprehensive health check across all modules and produce a single status report.
+This skill replaces running /build, /test, /check-imports, and /migration-status separately.
+
+## Steps
+
+### 1. Full Build
+
+```bash
+JAVA_HOME=/home/themeinerlp/.sdkman/candidates/java/25.0.1-open PATH="/home/themeinerlp/.sdkman/candidates/java/25.0.1-open/bin:$PATH" ./gradlew build --no-daemon 2>&1 | tail -20
+```
+
+Record: BUILD SUCCESS or BUILD FAILED. If FAILED, capture the error lines (lines containing "error:" or "FAILED").
+
+### 2. All Tests (including ArchUnit)
+
+```bash
+JAVA_HOME=/home/themeinerlp/.sdkman/candidates/java/25.0.1-open PATH="/home/themeinerlp/.sdkman/candidates/java/25.0.1-open/bin:$PATH" ./gradlew test --no-daemon 2>&1 | grep -E "PASSED|FAILED|ERROR|tests|ArchUnit"
+```
+
+Record: total passed, total failed, total errors. ArchUnit tests live in `server/src/test/java/net/elytrarace/arch/` and run as part of the normal test task.
+
+### 3. Import Isolation — shared/ (must be zero)
+
+Check that shared modules contain no platform-specific imports:
+
+```bash
+grep -rc "org.bukkit" shared/ --include="*.java" | grep -v ":0"
+grep -rc "io.papermc" shared/ --include="*.java" | grep -v ":0"
+grep -rc "net.minestom" shared/ --include="*.java" | grep -v ":0"
+```
+
+Any output line is a violation. No output means clean.
+
+### 4. Import Isolation — server/ (must be zero)
+
+Check that the server module contains no Bukkit/Paper imports:
+
+```bash
+grep -rc "org.bukkit" server/ --include="*.java" | grep -v ":0"
+grep -rc "io.papermc" server/ --include="*.java" | grep -v ":0"
+```
+
+Also verify that server/ does not import plugin packages:
+
+```bash
+grep -rc "net.elytrarace.game" server/ --include="*.java" | grep -v ":0"
+grep -rc "net.elytrarace.setup" server/ --include="*.java" | grep -v ":0"
+```
+
+### 5. Migration Status Summary
+
+Read `docs/migration/status.md` and extract the milestone table. Count open items from the Open Items section.
+
+Also collect source file counts:
+
+```bash
+find server/src/main -name "*.java" | wc -l
+find server/src/test -name "*.java" | wc -l
+```
+
+## Output
+
+Produce a report with the following sections. Mark each section OK or FAILED.
+
+```
+=== Voyager Health Check ===
+
+Build:            OK | FAILED
+                  (error summary if FAILED)
+
+Tests:            X passed / Y failed / Z errors
+                  (list failing test names if any)
+
+Import isolation:
+  shared/ Bukkit: OK | VIOLATIONS (list files)
+  shared/ Paper:  OK | VIOLATIONS (list files)
+  shared/ Minestom: OK | VIOLATIONS (list files)
+  server/ Bukkit: OK | VIOLATIONS (list files)
+  server/ Paper:  OK | VIOLATIONS (list files)
+  server/ plugin imports: OK | VIOLATIONS (list files)
+
+Migration:
+  M1 Foundation:      Complete  (6/6)
+  M2 Shared Cleanup:  <status>  (<n>/5)
+  M3 Core Game:       <status>  (<n>/7)
+  M4 Gameplay:        <status>  (<n>/7)
+  M5 Polish & Deploy: <status>  (<n>/9)
+  Server source files: <n> main / <m> test
+  Open high-priority items: <count>
+
+Overall: GREEN (all checks passed) | RED (see above)
+```
+
+Overall is GREEN only when Build is OK, all tests pass, and import isolation has zero violations. Migration status is informational and does not affect the GREEN/RED verdict.


### PR DESCRIPTION
## What changed?

8 new Claude Code skills (slash-commands) for recurring workflows in the Voyager project. These reduce manual lookup overhead and enforce project conventions automatically.

| Skill | Purpose |
|---|---|
| `/add-translation` | Add an i18n key — enforces MiniMessage `<arg:N>` instead of `{N}` |
| `/create-service` | Sealed interface + DefaultImpl + JUnit 5 test (ManisGame pattern) |
| `/create-phase` | Minestom phase with `start()`/`finish()` + GamePhaseFactory registration |
| `/create-repository` | Hibernate repository following the ManisGame sealed-interface pattern |
| `/create-adapter` | Gson `JsonDeserializer` in the `adapter` subpackage (Rule 8) |
| `/health-check` | Build + tests + ArchUnit + import isolation in one report |
| `/db-start` | Start MariaDB Docker + health check + connection info |
| `/create-pr` | GitHub PR with project template targeting `main` |

**Related issues (not closing, but supporting the workflows for):**
- #141 — Multi-language support validation: `/add-translation` enforces correct i18n conventions
- #123 — Integration tests lifecycle: `/health-check` runs full test + ArchUnit suite in one step
- #124 — Docker + CloudNet deployment: `/db-start` covers local MariaDB setup

## Type

- [x] `feat:` — new feature

## Checklist

- [x] PR title follows Conventional Commits (`feat(skills): ...`)
- [x] Tests present and passing (skills are instruction files, not executable code)
- [x] No new code without tests
- [ ] Breaking change? → no

---

Generated with [Claude Code](https://claude.ai/referral/m5Ak2Sa7aQ)